### PR TITLE
Updated to use taask.xyz

### DIFF
--- a/404.html
+++ b/404.html
@@ -14,7 +14,7 @@
 
 <header>
   <div class="container clearfix">
-    <a class="path" href="https://core.taask.io/">[Home]</a>
+    <a class="path" href="https://core.taask.xyz/">[Home]</a>
     <span class="caret"># _</span>
     <div class="right">
       <a class="path" href="/news">[/News]</a>

--- a/categories/index.html
+++ b/categories/index.html
@@ -14,7 +14,7 @@
 
 <header>
   <div class="container clearfix">
-    <a class="path" href="https://core.taask.io/">[Home]</a>
+    <a class="path" href="https://core.taask.xyz/">[Home]</a>
     <span class="caret"># _</span>
     <div class="right">
       <a class="path" href="/news">[/News]</a>

--- a/categories/index.xml
+++ b/categories/index.xml
@@ -2,12 +2,12 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Categories on Taask Core</title>
-    <link>https://core.taask.io/categories/</link>
+    <link>https://core.taask.xyz/categories/</link>
     <description>Recent content in Categories on Taask Core</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
     
-	<atom:link href="https://core.taask.io/categories/index.xml" rel="self" type="application/rss+xml" />
+	<atom:link href="https://core.taask.xyz/categories/index.xml" rel="self" type="application/rss+xml" />
     
     
   </channel>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
 <header>
   <div class="container clearfix">
-    <a class="path" href="https://core.taask.io/">[Home]</a>
+    <a class="path" href="https://core.taask.xyz/">[Home]</a>
     <span class="caret"># _</span>
     <div class="right">
       <a class="path" href="/news">[/News]</a>

--- a/index.xml
+++ b/index.xml
@@ -2,21 +2,21 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Taask Core</title>
-    <link>https://core.taask.io/</link>
+    <link>https://core.taask.xyz/</link>
     <description>Recent content on Taask Core</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
     <lastBuildDate>Sat, 15 Dec 2018 13:40:06 -0500</lastBuildDate>
     
-	<atom:link href="https://core.taask.io/index.xml" rel="self" type="application/rss+xml" />
+	<atom:link href="https://core.taask.xyz/index.xml" rel="self" type="application/rss+xml" />
     
     
     <item>
       <title>Taask Core on GitHub</title>
-      <link>https://core.taask.io/news/taask-core/</link>
+      <link>https://core.taask.xyz/news/taask-core/</link>
       <pubDate>Sat, 15 Dec 2018 13:40:06 -0500</pubDate>
       
-      <guid>https://core.taask.io/news/taask-core/</guid>
+      <guid>https://core.taask.xyz/news/taask-core/</guid>
       <description>Taask on GitHub
 👋 Welcome!
 Taask Core is an open source system for running arbitrary jobs on any infrastructure. In other words, cloud native tasks-as-a-service.

--- a/news/index.html
+++ b/news/index.html
@@ -14,7 +14,7 @@
 
 <header>
   <div class="container clearfix">
-    <a class="path" href="https://core.taask.io/">[Home]</a>
+    <a class="path" href="https://core.taask.xyz/">[Home]</a>
     <span class="caret"># _</span>
     <div class="right">
       <a class="path" href="/news">[/News]</a>

--- a/news/index.xml
+++ b/news/index.xml
@@ -2,21 +2,21 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>News on Taask Core</title>
-    <link>https://core.taask.io/news/</link>
+    <link>https://core.taask.xyz/news/</link>
     <description>Recent content in News on Taask Core</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
     <lastBuildDate>Sat, 15 Dec 2018 13:40:06 -0500</lastBuildDate>
     
-	<atom:link href="https://core.taask.io/news/index.xml" rel="self" type="application/rss+xml" />
+	<atom:link href="https://core.taask.xyz/news/index.xml" rel="self" type="application/rss+xml" />
     
     
     <item>
       <title>Taask Core on GitHub</title>
-      <link>https://core.taask.io/news/taask-core/</link>
+      <link>https://core.taask.xyz/news/taask-core/</link>
       <pubDate>Sat, 15 Dec 2018 13:40:06 -0500</pubDate>
       
-      <guid>https://core.taask.io/news/taask-core/</guid>
+      <guid>https://core.taask.xyz/news/taask-core/</guid>
       <description>Taask on GitHub
 👋 Welcome!
 Taask Core is an open source system for running arbitrary jobs on any infrastructure. In other words, cloud native tasks-as-a-service.

--- a/news/taask-core/index.html
+++ b/news/taask-core/index.html
@@ -14,7 +14,7 @@
 
 <header>
   <div class="container clearfix">
-    <a class="path" href="https://core.taask.io/">[Home]</a>
+    <a class="path" href="https://core.taask.xyz/">[Home]</a>
     <span class="caret"># _</span>
     <div class="right">
       <a class="path" href="/news">[/News]</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,29 +3,29 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   
   <url>
-    <loc>https://core.taask.io/news/taask-core/</loc>
+    <loc>https://core.taask.xyz/news/taask-core/</loc>
     <lastmod>2018-12-15T13:40:06-05:00</lastmod>
   </url>
   
   <url>
-    <loc>https://core.taask.io/categories/</loc>
+    <loc>https://core.taask.xyz/categories/</loc>
     <priority>0</priority>
   </url>
   
   <url>
-    <loc>https://core.taask.io/news/</loc>
-    <lastmod>2018-12-15T13:40:06-05:00</lastmod>
-    <priority>0</priority>
-  </url>
-  
-  <url>
-    <loc>https://core.taask.io/</loc>
+    <loc>https://core.taask.xyz/news/</loc>
     <lastmod>2018-12-15T13:40:06-05:00</lastmod>
     <priority>0</priority>
   </url>
   
   <url>
-    <loc>https://core.taask.io/tags/</loc>
+    <loc>https://core.taask.xyz/</loc>
+    <lastmod>2018-12-15T13:40:06-05:00</lastmod>
+    <priority>0</priority>
+  </url>
+  
+  <url>
+    <loc>https://core.taask.xyz/tags/</loc>
     <priority>0</priority>
   </url>
   

--- a/taask/config.toml
+++ b/taask/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://core.taask.io/"
+baseURL = "https://core.taask.xyz/"
 languageCode = "en-us"
 title = "Taask Core"
 theme = "base16"

--- a/tags/index.html
+++ b/tags/index.html
@@ -14,7 +14,7 @@
 
 <header>
   <div class="container clearfix">
-    <a class="path" href="https://core.taask.io/">[Home]</a>
+    <a class="path" href="https://core.taask.xyz/">[Home]</a>
     <span class="caret"># _</span>
     <div class="right">
       <a class="path" href="/news">[/News]</a>

--- a/tags/index.xml
+++ b/tags/index.xml
@@ -2,12 +2,12 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Tags on Taask Core</title>
-    <link>https://core.taask.io/tags/</link>
+    <link>https://core.taask.xyz/tags/</link>
     <description>Recent content in Tags on Taask Core</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
     
-	<atom:link href="https://core.taask.io/tags/index.xml" rel="self" type="application/rss+xml" />
+	<atom:link href="https://core.taask.xyz/tags/index.xml" rel="self" type="application/rss+xml" />
     
     
   </channel>


### PR DESCRIPTION
Noticed that the home link on the [Taask website](https://core.taask.xyz/) points to `core.task.io`, which appears to be dead.  I updated the site to use `core.taask.xyz` instead, which should fix the home button.